### PR TITLE
fix: remove card from maxikanban only if kanban is inside config

### DIFF
--- a/src/ruleFinder/ProjectCardRuleFinder.js
+++ b/src/ruleFinder/ProjectCardRuleFinder.js
@@ -172,7 +172,7 @@ module.exports = class ProjectCardRuleFinder {
       await mooveInSameColumn(cardColumnId);
     }
 
-    if (Utils.contextHasAction(context, 'deleted')) {
+    if (Utils.contextHasAction(context, 'deleted') && config) {
       const issueGraphqlData = await getIssue(context.github, issueRepo, issueOwner, issueId);
       await deleteCard(context.github, this.config.maxiKanban.id, issueGraphqlData);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We need to remove the card from the maxikanban only if the kanban exist in the config of the project
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
