### PR TITLE
Feat: Integration deployment

### DIFF
--- a/.github/workflows/integration-deployment.yml
+++ b/.github/workflows/integration-deployment.yml
@@ -1,0 +1,31 @@
+name: IssueBot Integration CICD
+
+concurrency:
+  group: issuebot-${{ github.ref }}
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled]
+
+jobs:
+
+  issuebot-integration:
+    name: Trigger Integration CICD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: contains(github.event.pull_request.labels.*.name, 'integration deployment')
+
+    steps:
+
+      - name: Get tag
+        shell: bash
+        id: get_tag
+        run: echo TAG=$(echo $GITHUB_REF | cut -d / -f 3) >> $GITHUB_OUTPUT
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ISSUEBOT_CD_PAT }}
+          repository: ${{ secrets.ISSUEBOT_CD_REPOSITORY }}
+          event-type: integration_deployment
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "tag": "${{ steps.get_tag.outputs.TAG }}"}'


### PR DESCRIPTION
Added draft workflow to securely trigger integration deployment

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Added integration deployment draft, subject to changes according to reviewers and OS team
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Added `integration deployment` label on this PR to trigger the workflow, which will trigger another workflow on a private repository and will take care of build and deployment
